### PR TITLE
Normalize negative term handling across workflows

### DIFF
--- a/server/my_app/routes/workflow_routes.py
+++ b/server/my_app/routes/workflow_routes.py
@@ -16,6 +16,7 @@ from my_app.services.workflow_logic_service import workflow_logic_service
 from my_app.services.export_manager import export_manager
 from my_app.services.inpainting_service import inpainting_service
 from my_app.utils.helpers import parse_hidden_commands
+from my_app.utils.negative_terms import normalize_negative_terms
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,7 @@ def execute_workflow():
         seed_mode = data.get('seedMode', 'random')
         custom_seed = data.get('customSeed', None)
         safety_level = data.get('safetyLevel', 'off')
-        input_negative_terms = data.get('inputNegativeTerms', '')
+        input_negative_terms = normalize_negative_terms(data.get('inputNegativeTerms'))
         
         # Input mode and image data
         image_data = data.get('imageData')

--- a/server/my_app/services/workflow_logic_service.py
+++ b/server/my_app/services/workflow_logic_service.py
@@ -22,8 +22,9 @@ from config import (
 )
 from my_app.utils.helpers import (
     calculate_dimensions,
-    parse_model_name
+    parse_model_name,
 )
+from my_app.utils.negative_terms import normalize_negative_terms
 from my_app.services.model_path_resolver import ModelPathResolver
 
 logger = logging.getLogger(__name__)
@@ -459,6 +460,7 @@ class WorkflowLogicService:
         Returns:
             Number of negative prompts enhanced
         """
+        input_negative_terms = normalize_negative_terms(input_negative_terms)
         enhanced_count = 0
         
         logger.info(f"=== Starting {safety_level} safety enhancement ===")
@@ -689,6 +691,8 @@ class WorkflowLogicService:
         Returns:
             Dictionary with workflow, status_updates, used_seed, and success flag
         """
+        input_negative_terms = normalize_negative_terms(input_negative_terms)
+
         # Load workflow
         workflow = self.load_workflow(workflow_name)
         if not workflow:

--- a/server/my_app/utils/helpers.py
+++ b/server/my_app/utils/helpers.py
@@ -152,5 +152,6 @@ def parse_hidden_commands(prompt):
     
     # Clean up multiple spaces
     clean_prompt = re.sub(r'\s+', ' ', prompt).strip()
-    
+
     return clean_prompt, commands
+

--- a/server/my_app/utils/negative_terms.py
+++ b/server/my_app/utils/negative_terms.py
@@ -1,0 +1,20 @@
+"""Utilities for handling negative terms."""
+
+
+def normalize_negative_terms(value: str | list | None) -> str:
+    """Normalize negative terms to a comma-separated string.
+
+    Args:
+        value: Negative terms provided as a string, list, or None.
+
+    Returns:
+        A string with comma-separated negative terms. Returns an empty string
+        if the input is None or empty.
+    """
+    if value is None:
+        return ""
+
+    if isinstance(value, list):
+        return ", ".join(str(v).strip() for v in value if str(v).strip())
+
+    return str(value).strip()

--- a/tests/test_negative_terms.py
+++ b/tests/test_negative_terms.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+sys.path.append(str(ROOT_DIR / "server"))
+
+from server.my_app.utils.negative_terms import normalize_negative_terms
+
+
+def test_normalize_negative_terms_string():
+    assert normalize_negative_terms("  hello world  ") == "hello world"
+
+
+def test_normalize_negative_terms_list():
+    assert (
+        normalize_negative_terms(["  foo", "bar ", " baz"]) == "foo, bar, baz"
+    )
+
+
+def test_normalize_negative_terms_none():
+    assert normalize_negative_terms(None) == ""
+    assert normalize_negative_terms("") == ""
+    assert normalize_negative_terms([]) == ""
+
+
+def test_normalize_negative_terms_list_and_string_equivalence():
+    terms_list = ["cat", "dog"]
+    terms_str = "cat, dog"
+    assert normalize_negative_terms(terms_list) == normalize_negative_terms(terms_str)
+


### PR DESCRIPTION
## Summary
- add `normalize_negative_terms` helper to standardize negative term inputs
- use helper in workflow routes and logic service
- test normalization for strings, lists, and null values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896655e9a2083319e85eb3f68a96c66