### PR TITLE
Use categories when filtering random workflows

### DIFF
--- a/public/js/workflow-streaming.js
+++ b/public/js/workflow-streaming.js
@@ -24,12 +24,31 @@ export async function submitPromptWithFastPolling() {
     clearOutputDisplays();
     startProcessingDisplay("Generierung...");
 
-    const workflowName = ui.workflow.value;
+    let workflowName = ui.workflow.value;
     const promptText = ui.prompt.value.trim();
     const selectedRadio = document.querySelector('input[name="aspectRatio"]:checked');
     const aspectRatio = selectedRadio ? selectedRadio.value : '1:1';
     const executionMode = document.querySelector('input[name="execution-mode"]:checked').value;
     const safetyLevel = document.querySelector('input[name="safety-level"]:checked').value;
+
+    if (workflowName === '__random__') {
+        const allowedCategories = ['semantics', 'arts', 'aesthetics'];
+        const randomOptions = Array.from(ui.workflow.options).filter(opt => {
+            if (!opt.value || opt.value === '__random__') return false;
+            return allowedCategories.some(cat => opt.value.startsWith(`${cat}/`));
+        });
+
+        if (randomOptions.length > 0) {
+            const randomOption = randomOptions[Math.floor(Math.random() * randomOptions.length)];
+            workflowName = randomOption.value;
+            ui.workflow.value = workflowName;
+            ui.workflow.dispatchEvent(new Event('change'));
+        } else {
+            setStatus('Keine Workflows verfügbar.', 'error');
+            stopProcessingDisplay();
+            return;
+        }
+    }
 
     if (!workflowName) {
         setStatus('Bitte wählen Sie einen Workflow aus.', 'warning');


### PR DESCRIPTION
## Summary
- Replace hardcoded prefix list with category names for random workflow selection
- Aligns dropdown filtering with server's category naming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68999aee24d883319c659d482e91e295